### PR TITLE
Fix npm package contents

### DIFF
--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -69,8 +69,3 @@ jobs:
         uses: rainstormy-actions/release/tag@73fe3aae49ad74af650e529107d94f45002798fd # v1.1.0
         with:
           version: ${{ inputs.version || github.head_ref }}
-        #
-      - name: Create a major-only version tag in Git
-        uses: rainstormy-actions/release/major-tag@73fe3aae49ad74af650e529107d94f45002798fd # v1.1.0
-        with:
-          version: ${{ inputs.version || github.head_ref }}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"./storybook": "./dist/storybook.json",
 		"./test": "./dist/test.json"
 	},
+	"files": ["dist/"],
 	"packageManager": "pnpm@9.5.0+sha256.dbdf5961c32909fb030595a9daa1dae720162e658609a8f92f2fa99835510ca5",
 	"engines": {
 		"node": ">=20.0.0"


### PR DESCRIPTION
The npm package should only contain the build artifacts and package
metadata, not the entire source code.